### PR TITLE
Fix missing device_info crash

### DIFF
--- a/pgoapi/rpc_api.py
+++ b/pgoapi/rpc_api.py
@@ -212,8 +212,9 @@ class RpcApi:
             sig.timestamp = get_time(ms=True)
             sig.timestamp_since_start = get_time(ms=True) - RpcApi.START_TIME
 
-            for key in self.device_info:
-                setattr(sig.device_info, key, self.device_info[key])
+            if self.device_info:
+                for key in self.device_info:
+                    setattr(sig.device_info, key, self.device_info[key])
 
             signature_proto = sig.SerializeToString()
 


### PR DESCRIPTION
Fix this crash:
```
Traceback (most recent call last):
  File "./pokecli.py", line 139, in <module>
    main()
  File "./pokecli.py", line 134, in main
    response_dict = api.get_map_objects(latitude =position[0], longitude = position[1], since_timestamp_ms = timestamps, cell_id = cell_ids)
  File "/Users/kicktheken/Dropbox/playground/pgoapi/pgoapi/pgoapi.py", line 139, in function
    return request.call()
  File "/Users/kicktheken/Dropbox/playground/pgoapi/pgoapi/pgoapi.py", line 241, in call
    response = request.request(self._api_endpoint, self._req_method_list, self.get_position())
  File "/Users/kicktheken/Dropbox/playground/pgoapi/pgoapi/rpc_api.py", line 127, in request
    request_proto = self._build_main_request(subrequests, player_position)
  File "/Users/kicktheken/Dropbox/playground/pgoapi/pgoapi/rpc_api.py", line 215, in _build_main_request
    for key in self.device_info:
TypeError: 'NoneType' object is not iterable
```