### PR TITLE
Fix a bug which occurs when altitude isn't set. Fixes #171.

### DIFF
--- a/pgoapi/rpc_api.py
+++ b/pgoapi/rpc_api.py
@@ -199,7 +199,10 @@ class RpcApi:
         request.request_id = self.get_rpc_id()
 
         if player_position:
-            request.latitude, request.longitude, request.altitude = player_position
+            if player_position[2] == None:
+                request.latitude, request.longitude, _ = player_position
+            else:
+                request.latitude, request.longitude, request.altitude = player_position
         if not request.altitude or request.altitude == 0:
             request.altitude = random.choice((5, 5, 5, 5, 10, 10, 10, 30, 30, 50, 65, random.uniform(66,80)))
 


### PR DESCRIPTION
There is currently a bug in RpcApi._build_main_request where passing a player location with altitude unset (e,g, (123, 456, None) ) causes the automatic protobuf datatype checks to fail.

This resolves the bug by only setting request.latitude and request.longditude when an altitude value isn't passed.

Existing code then sets a (randomised) value for request.altitude.