### PR TITLE
Updated the README to include setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,27 @@ Documentation is available at the github [pgoapi wiki](https://wiki.pogodev.org)
  * geopy (only for pokecli demo)
  * s2sphere (only for pokecli demo)
 
-## Contribution
+## Use
+To use this api as part of a python project using setuptools/pip, modify your requirements.txt file to include:
+```
+git+https://github.com/pogodevorg/pgoapi.git@develop#egg=pgoapi
+```
+
+If you are not using setuptools/pip, follow the instructions in the Contributing section below to clone this repository and then install pgoapi using the appropriate method for your project.
+
+## Contributing
 Contributions are highly welcome. Please use github or [Discord](https://discord.pogodev.org) for it!
+
+You can get started by cloning this repository. Note that as pgoapi uses [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) you must perform a recursive clone:
+
+| Protocol | Command |
+| -------- | ------- |
+| HTTPS | `git clone --recursive https://github.com/pogodevorg/pgoapi.git` |
+| SSH   | `git clone --recursive git@github.com:pogodevorg/pgoapi.git` |
+
+If you already have a copy of the repository you can use `git submodule update --init` to fetch and update the submodules.
+
+Once you have cloned the repository, switch to the `develop` branch. To merge your changes back into the main repository, make a pull request to `develop`.
 
 ## Credits
 [Mila432](https://github.com/Mila432/Pokemon_Go_API) for the login secrets  


### PR DESCRIPTION
Added/edited two sections in the README:

* Created a new section 'Use', describing how to use pgoapi either through setuptools/pip (via requirements.txt) or through manual installation.
* Modified the 'Contribution' section to make it clear that in order to fetch the submodules you must perorm a recursive clone.