### PR TITLE
Keep support for Ubuntu 16.04.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 geopy==1.11.0
-protobuf>=3.0.0a3
+protobuf==3.1.0.post1
 requests==2.10.0
 s2sphere==0.2.4
 gpsoauth==0.4.0


### PR DESCRIPTION
protobuf 3.2.0rc1 released yesterday breaks support for Ubuntu 16.04 for several PokémonGo-Map users.