### PR TITLE
PTC login improvements

### DIFF
--- a/pgoapi/auth_ptc.py
+++ b/pgoapi/auth_ptc.py
@@ -35,7 +35,7 @@ from six import string_types
 
 from pgoapi.auth import Auth
 from pgoapi.utilities import get_time
-from pgoapi.exceptions import AuthException, InvalidCredentialsException
+from pgoapi.exceptions import AuthException, AuthTimeoutException, InvalidCredentialsException
 
 from requests.exceptions import RequestException, Timeout
 
@@ -71,7 +71,7 @@ class AuthPtc(Auth):
         try:
             r = self._session.get(self.PTC_LOGIN_URL, timeout=15)
         except Timeout:
-            raise AuthException('Request timed out.')
+            raise AuthTimeoutException('Auth GET timed out.')
         except RequestException as e:
             raise AuthException('Caught RequestException: {}'.format(e))
 
@@ -84,12 +84,12 @@ class AuthPtc(Auth):
             })
         except (ValueError, AttributeError) as e:
             self.log.error('PTC User Login Error - invalid JSON response: {}'.format(e))
-            return False
+            raise AuthException('Invalid JSON response: {}'.format(e))
 
         try:
             r = self._session.post(self.PTC_LOGIN_URL, data=data, timeout=15, allow_redirects=False)
         except Timeout:
-            raise AuthException('Request timed out.')
+            raise AuthTimeoutException('Auth POST timed out.')
         except RequestException as e:
             raise AuthException('Caught RequestException: {}'.format(e))
 
@@ -97,8 +97,7 @@ class AuthPtc(Auth):
             qs = parse_qs(urlsplit(r.headers['Location'])[3])
             self._refresh_token = qs.get('ticket')[0]
         except Exception as e:
-            self.log.error('Could not retrieve token! {}'.format(e))
-            return False
+            raise AuthException('Could not retrieve token! {}'.format(e))
 
         self._access_token = self._session.cookies.get('CASTGC')
         if self._access_token:
@@ -139,7 +138,7 @@ class AuthPtc(Auth):
             try:
                 r = self._session.post(self.PTC_LOGIN_OAUTH, data=data, timeout=15)
             except Timeout:
-                raise AuthException('Request timed out.')
+                raise AuthTimeoutException('Auth POST timed out.')
             except RequestException as e:
                 raise AuthException('Caught RequestException: {}'.format(e))
 

--- a/pgoapi/auth_ptc.py
+++ b/pgoapi/auth_ptc.py
@@ -45,13 +45,13 @@ class AuthPtc(Auth):
     PTC_LOGIN_OAUTH = 'https://sso.pokemon.com/sso/oauth2.0/accessToken'
     PTC_LOGIN_CLIENT_SECRET = 'w8ScCUXJQc6kXKw8FiOhd8Fixzht18Dq3PEVkUCP5ZPxtgyWsbTvWHFLm2wNY0JR'
 
-    def __init__(self, username=None, password=None):
+    def __init__(self, username=None, password=None, user_agent='pokemongo/0 CFNetwork/758.5.3 Darwin/15.6.0'):
         Auth.__init__(self)
 
         self._auth_provider = 'ptc'
 
         self._session = requests.session()
-        self._session.headers = {'User-Agent': 'pokemongo/0 CFNetwork/758.5.3 Darwin/15.6.0'}
+        self._session.headers = {'User-Agent': user_agent}
         self._username = username
         self._password = password
 

--- a/pgoapi/exceptions.py
+++ b/pgoapi/exceptions.py
@@ -30,9 +30,15 @@ class PgoapiError(Exception):
 class HashServerException(PgoapiError):
     """Parent class of all hashing server errors"""
 
+class TimeoutException(PgoapiError):
+    """Raised when a request times out."""
+
 
 class AuthException(PgoapiError):
     """Raised when logging in fails"""
+
+class AuthTimeoutException(AuthException, TimeoutException):
+    """Raised when an auth request times out."""
 
 class InvalidCredentialsException(AuthException, ValueError):
     """Raised when the username, password, or provider are empty/invalid"""
@@ -77,8 +83,14 @@ class ServerBusyOrOfflineException(PgoapiError):
 class NianticOfflineException(ServerBusyOrOfflineException):
     """Raised when unable to establish a conection with Niantic"""
 
+class NianticTimeoutException(NianticOfflineException, TimeoutException):
+    """Raised when an RPC request times out."""
+
 class HashingOfflineException(ServerBusyOrOfflineException, HashServerException):
     """Raised when unable to establish a conection with the hashing server"""
+
+class HashingTimeoutException(HashingOfflineException, TimeoutException):
+    """Raised when a request to the hashing server times out."""
 
 
 class PleaseInstallProtobufVersion3(PgoapiError):

--- a/pgoapi/hash_server.py
+++ b/pgoapi/hash_server.py
@@ -5,7 +5,7 @@ import base64
 import requests
 
 from pgoapi.hash_engine import HashEngine
-from pgoapi.exceptions import BadHashRequestException, HashingOfflineException, HashingQuotaExceededException, MalformedHashResponseException, TempHashingBanException, UnexpectedHashResponseException
+from pgoapi.exceptions import BadHashRequestException, HashingOfflineException, HashingQuotaExceededException, HashingTimeoutException, MalformedHashResponseException, TempHashingBanException, UnexpectedHashResponseException
 
 class HashServer(HashEngine):
     _session = requests.session()
@@ -38,7 +38,9 @@ class HashServer(HashEngine):
         # request hashes from hashing server
         try:
             response = self._session.post(self.endpoint, json=payload, headers=self.headers, timeout=30)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as error:
+        except requests.exceptions.Timeout:
+            raise HashingTimeoutException('Hashing request timed out.')
+        except requests.exceptions.ConnectionError as error:
             raise HashingOfflineException(error)
 
         if response.status_code == 400:

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -74,12 +74,9 @@ class PGoApi:
     def set_logger(self, logger=None):
         self.log = logger or logging.getLogger(__name__)
 
-    def set_authentication(self, provider=None, oauth2_refresh_token=None, username=None, password=None, proxy_config=None, user_agent=None):
+    def set_authentication(self, provider=None, oauth2_refresh_token=None, username=None, password=None, proxy_config=None, user_agent=None, timeout=None):
         if provider == 'ptc':
-            if user_agent:
-                self._auth_provider = AuthPtc(user_agent=user_agent)
-            else:
-                self._auth_provider = AuthPtc()
+            self._auth_provider = AuthPtc(user_agent=user_agent, timeout=timeout)
         elif provider == 'google':
             self._auth_provider = AuthGoogle()
         elif provider is None:

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -74,9 +74,12 @@ class PGoApi:
     def set_logger(self, logger=None):
         self.log = logger or logging.getLogger(__name__)
 
-    def set_authentication(self, provider=None, oauth2_refresh_token=None, username=None, password=None, proxy_config=None):
+    def set_authentication(self, provider=None, oauth2_refresh_token=None, username=None, password=None, proxy_config=None, user_agent=None):
         if provider == 'ptc':
-            self._auth_provider = AuthPtc()
+            if user_agent:
+                self._auth_provider = AuthPtc(user_agent=user_agent)
+            else:
+                self._auth_provider = AuthPtc()
         elif provider == 'google':
             self._auth_provider = AuthGoogle()
         elif provider is None:

--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -84,7 +84,7 @@ class PGoApi:
         else:
             raise InvalidCredentialsException("Invalid authentication provider - only ptc/google available.")
 
-        self.log.debug('Auth provider: %s', provider)
+        self.log.debug('Auth provider: {}'.format(provider))
 
         if proxy_config:
             self._auth_provider.set_proxy(proxy_config)
@@ -270,8 +270,8 @@ class PGoApiRequest:
                 try:
                     self.log.info('Access Token rejected! Requesting new one...')
                     self._auth_provider.get_access_token(force_refresh=True)
-                except Exception:
-                    error = 'Request for new Access Token failed! Logged out...'
+                except Exception as e:
+                    error = 'Reauthentication failed: {}'.format(e)
                     self.log.error(error)
                     raise NotLoggedInException(error)
 
@@ -287,7 +287,6 @@ class PGoApiRequest:
                 execute = True  # reexecute the call
 
         # cleanup after call execution
-        self.log.info('Cleanup of request!')
         self._req_method_list = []
 
         return response

--- a/pgoapi/rpc_api.py
+++ b/pgoapi/rpc_api.py
@@ -41,7 +41,7 @@ from protobuf_to_dict import protobuf_to_dict
 
 from importlib import import_module
 
-from pgoapi.exceptions import AuthTokenExpiredException, BadRequestException, MalformedNianticResponseException, NianticIPBannedException, NianticOfflineException, NianticThrottlingException, NotLoggedInException, ServerApiEndpointRedirectException, UnexpectedResponseException
+from pgoapi.exceptions import AuthTokenExpiredException, BadRequestException, MalformedNianticResponseException, NianticIPBannedException, NianticOfflineException, NianticThrottlingException, NianticTimeoutException, NotLoggedInException, ServerApiEndpointRedirectException, UnexpectedResponseException
 from pgoapi.utilities import to_camel_case, get_time, get_format_time_diff, Rand48, long_to_bytes, f2i
 from pgoapi.hash_library import HashLibrary
 from pgoapi.hash_engine import HashEngine
@@ -134,7 +134,9 @@ class RpcApi:
         request_proto_serialized = request_proto_plain.SerializeToString()
         try:
             http_response = self._session.post(endpoint, data=request_proto_serialized, timeout=30)
-        except (requests.exceptions.Timeout, requests.exceptions.ConnectionError) as e:
+        except requests.exceptions.Timeout:
+            raise NianticTimeoutException('RPC request timed out.')
+        except requests.exceptions.ConnectionError as e:
             raise NianticOfflineException(e)
 
         return http_response


### PR DESCRIPTION
Use fewer requests to get access token, use urllib instead of regex to extract ticket, catch more requests exceptions, fallback to using credentials on reauth if refresh token fails, use user-agent from iOS, timeout after 15 seconds on each request, use `.json()` and `.text` instead of manually decoding `.content`, some cleanup, don't allow redirects and just retrieve the ticket from the headers of the first request, log the exception message on reauthentication.