### PR TITLE
Update uk25 for 0.45 to fix non hash server integrations.

### DIFF
--- a/pgoapi/rpc_api.py
+++ b/pgoapi/rpc_api.py
@@ -288,7 +288,7 @@ class RpcApi:
             sen.status = 3
 
             if self._api_version == "0_45":
-                sig.unknown25 = -1553869577012279119
+                sig.unknown25 = -816976800928766045
             else:
                 sig.unknown25 = -816976800928766045
 


### PR DESCRIPTION
Hardcode to 0.57.2 uk25 value or remove the 0.45 check completely. Either works, but uk25 needs to be updated to allow 0.45 users without paid hash key to continue to utilize pgoapi.

Tested and working across three server instances over the past 24 hours. No issues.

Let me know if you have any questions or require adjustments. I think there are quite a few people waiting for this change to be pushed so they can get their projects back online.

-voxx