### PR TITLE
Add token to HashServer status

### DIFF
--- a/pgoapi/hash_server.py
+++ b/pgoapi/hash_server.py
@@ -65,6 +65,7 @@ class HashServer(HashEngine):
             self.status['remaining'] = int(headers['X-RateRequestsRemaining'])
             self.status['maximum'] = int(headers['X-MaxRequestCount'])
             self.status['expiration'] = int(headers['X-AuthTokenExpiration'])
+            self.status['token'] = self.headers['X-AuthTokenExpiration']
         except (KeyError, TypeError, ValueError):
             pass
 

--- a/pgoapi/hash_server.py
+++ b/pgoapi/hash_server.py
@@ -65,7 +65,7 @@ class HashServer(HashEngine):
             self.status['remaining'] = int(headers['X-RateRequestsRemaining'])
             self.status['maximum'] = int(headers['X-MaxRequestCount'])
             self.status['expiration'] = int(headers['X-AuthTokenExpiration'])
-            self.status['token'] = self.headers['X-AuthTokenExpiration']
+            self.status['token'] = self.headers['X-AuthToken']
         except (KeyError, TypeError, ValueError):
             pass
 


### PR DESCRIPTION
I have been doing some work which involves accessing the hashing data. It seems it would be useful to also return the token used in the last request, as this may differ from the current token if no new request has been made.