### PR TITLE
Add option for return protobuf data instead of dict

### DIFF
--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -226,7 +226,7 @@ class PGoApiRequest:
         self._req_method_list = []
         self.device_info = device_info
 
-    def call(self):
+    def call(self, use_dict = True):
         if (self._position_lat is None) or (self._position_lng is None):
             raise NoPlayerPositionSetException
 
@@ -248,7 +248,7 @@ class PGoApiRequest:
             execute = False
 
             try:
-                response = request.request(self._api_endpoint, self._req_method_list, self.get_position())
+                response = request.request(self._api_endpoint, self._req_method_list, self.get_position(), use_dict)
             except AuthTokenExpiredException as e:
                 """
                 This exception only occures if the OAUTH service provider (google/ptc) didn't send any expiration date


### PR DESCRIPTION
Add a call parameter that does not convert responses to dict.
Converting protobuf2dict it is slow, consumes more memory and has problems with falsy values (not really sure about the last one).

This PR makes the default behaviour the same even if it is worse as otherwise it would break all applications currently using the api. I did add an optional parameter to call so you can choose the format of the response returned by the api that defaults to current behaviour.
Another option would be adding a new function, this pr add more ifs that I would like but otherwise a lot of code would be duplicated.

In my tests parsing a single response goes from 0.1-0.05 sec to 0.01-0.001 sec so it is between 1 and 2 orders of magnitude faster.
Memory consumption is not mesaured as easily as protobuf objects do not return a real value with sys.getsizeof() but given that we are removing all key dicts and that most of the info returned are just ints the size should be less than half the size of the dict.

Also using the values returned should be faster too even when dicts have a constant access time that k it is greater than accessing object properties directly as there is no need to hash the key.

Fixes #197 