### PR TITLE
Fix PTC user agent

### DIFF
--- a/pgoapi/auth_ptc.py
+++ b/pgoapi/auth_ptc.py
@@ -50,7 +50,7 @@ class AuthPtc(Auth):
         self._auth_provider = 'ptc'
 
         self._session = requests.session()
-        self._session.headers = {'User-Agent': user_agent or 'pokemongo/0 CFNetwork/758.5.3 Darwin/15.6.0'}
+        self._session.headers = {'User-Agent': user_agent or 'pokemongo/1 CFNetwork/811.4.18 Darwin/16.5.0'}
         self._username = username
         self._password = password
         self.timeout = timeout or 15


### PR DESCRIPTION
Some people are currently having PTC login issues `ValueError: No JSON object could be decoded`. I tracked it down to the User-Agent which is being used in the login requests.

Sample code (current pgoapi implementation) which gives a 404 error on my system:
```python
headers = {
    'User-Agent': 'pokemongo/0 CFNetwork/758.5.3 Darwin/15.6.0'
}
PTC_LOGIN_URL = 'https://sso.pokemon.com/sso/login?service=https%3A%2F%2Fsso.pokemon.com%2Fsso%2Foauth2.0%2FcallbackAuthorize'
r = requests.request('GET', PTC_LOGIN_URL, headers=headers)
print r
print r.json()
```
Output:
```
<Response [404]>
[...]
ValueError: No JSON object could be decoded
```

Changing the User-Agent to `pokemongo/1 CFNetwork/811.4.18 Darwin/16.5.0` (thanks niico!) gives:
```
<Response [200]>
{u'lt': u'LT-36858557-KAvoLPaVkFLZtoOra4r6PZYKta6Fk0', u'execution': u'e1s1'}
```
