### PR TITLE
Increased app_version for download_remote_config_version request to 6304

### DIFF
--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -162,7 +162,7 @@ class PGoApi:
         time.sleep(1.5)
 
         request = self.create_request()
-        request.download_remote_config_version(platform=1, app_version=6301)
+        request.download_remote_config_version(platform=1, app_version=6304)
         request.check_challenge()
         request.get_hatched_eggs()
         request.get_inventory()


### PR DESCRIPTION
Bossland guys wrote in #api-hashing-support:

> The last version didn't change anything in hashing & co. Just the version number aka VersionInteger has been changed to 6304.

This version is being used in `app_simulation_login()`. I don't know who calls this method but we should use the most recent version there.