### PR TITLE
Add support for platform requests

### DIFF
--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -336,7 +336,3 @@ class PGoApiRequest:
             return add_platform
         else:
             raise AttributeError
-
-
-    
-        


### PR DESCRIPTION
Supports only sending them, there is no response parsing right now.
Also changed ptr8 implementation to the one used in python3
And refactored request list of dicts/int to a list of tuples with the second value as none when there is no params, that makes all the handling a lot easier.

I have made some tests and I am running my map on this version to be sure there is no issue with the changes.