### PR TITLE
Added get api version to api

### DIFF
--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -72,6 +72,9 @@ class PGoApi:
     def set_logger(self, logger=None):
         self.log = logger or logging.getLogger(__name__)
 
+    def get_api_version(self):
+        return 6701
+        
     def set_authentication(self, provider=None, oauth2_refresh_token=None, username=None, password=None, proxy_config=None, user_agent=None, timeout=None):
         if provider == 'ptc':
             self._auth_provider = AuthPtc(user_agent=user_agent, timeout=timeout)
@@ -162,7 +165,7 @@ class PGoApi:
         time.sleep(1.5)
 
         request = self.create_request()
-        request.download_remote_config_version(platform=1, app_version=6701)
+        request.download_remote_config_version(platform=1, app_version=self.get_api_version())
         request.check_challenge()
         request.get_hatched_eggs()
         request.get_inventory()


### PR DESCRIPTION
As we disscused in discord this is only another tool to avoid user errors, it takes the same amount of time to mantain as the value was being used in the login provided and will help app developers to diagnose and check that the correct api version is installed.