### PR TITLE
Make version function static

### DIFF
--- a/pgoapi/pgoapi.py
+++ b/pgoapi/pgoapi.py
@@ -73,9 +73,10 @@ class PGoApi:
     def set_logger(self, logger=None):
         self.log = logger or logging.getLogger(__name__)
 
-    def get_api_version(self):
+    @staticmethod
+    def get_api_version():
         return 6701
-        
+
     def set_authentication(self, provider=None, oauth2_refresh_token=None, username=None, password=None, proxy_config=None, user_agent=None, timeout=None):
         if provider == 'ptc':
             self._auth_provider = AuthPtc(user_agent=user_agent, timeout=timeout)


### PR DESCRIPTION
Forgot to make the function static and that hurts Seb feelings 😄 
I didn't test it but it should work using it as a static or regulard function according to the docs, so it is still backwards compatible with the previous PR.