### PR TITLE
Pin protobuf to 3.5.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 geopy>=1.11.0
-protobuf>=3.0.0
+protobuf==3.5.1
 requests[socks]>=2.10.0
 s2sphere>=0.2.4
 gpsoauth>=0.4.0


### PR DESCRIPTION
Fixes this problem with protobuf 3.5.2:
![image](https://user-images.githubusercontent.com/4874269/37398106-b4ccd7d6-277d-11e8-9464-7d3dfff0805a.png)

As reported and tested by 8 users so far.

Most users affected by this issue have it happen sporadically: on some startups everything works fine, on others it breaks with this error.

Other users have reported being unable to start anything at all (if it relies on pgoapi).

The issue is always with protobuf 3.5.2.