### PR TITLE
Fix compatibility w/ latest pip.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,11 @@
 
 import os
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+
+try:  # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError:  # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 setup_dir = os.path.dirname(os.path.realpath(__file__))
 path_req = os.path.join(setup_dir, 'requirements.txt')


### PR DESCRIPTION
It's been a while, pip got updated.

On pip >10, you'll get the following when trying to install pgoapi (e.g. via RM's requirements.txt):
```
ImportError: No module named pip.req
```

* Doesn't bring the project back to life, but it can serve as help for anyone porting their own scripts to newer versions.
* This also helps projects that expanded on RocketMap for real device scanning but that didn't remove the pgoapi requirement.

I've used the implementation that most fit the previous implementation, but I recommend changing to one that doesn't use pip internals, e.g.:
```
def parse_requirements(filename):
    """ Load requirements from a pip requirements file. """
    lineiter = (line.strip() for line in open(filename))
    return [line for line in lineiter if line and not line.startswith("#")]
```

More info: https://stackoverflow.com/questions/25192794/no-module-named-pip-req